### PR TITLE
Don't import GDBMError, fixes #6.

### DIFF
--- a/src/livestreamer_curses/main.py
+++ b/src/livestreamer_curses/main.py
@@ -173,7 +173,10 @@ class StreamList(object):
         try:
             f = shelve.open(filename, 'c')
         except Exception:
-            raise ShelveError('Database could not be opened, another livestreamer-curses instance might be already running.')
+            raise ShelveError(
+                'Database could not be opened, another livestreamer-curses instance might be already running. '
+                'Please note that a database created with Python 2.x cannot be used with Python 3.x and vice versa.'
+            )
         self.max_id = 0
 
         # Sort streams by view count


### PR DESCRIPTION
Not available on many platforms.

Unfortunately it makes this error less specific, but mixing up Python 2.x with 3.x should happen often anyways.
